### PR TITLE
Fix redundant GitHub requests during build process

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -201,12 +201,16 @@ module.exports = () => ({
 
             let sha;
 
-            try {
-                // User has good permissions, create an event
-                sha = await scm.getCommitSha(scmConfig);
-            } catch (err) {
-                if (err.statusCode) {
-                    throw boom.boomify(err, { statusCode: err.statusCode });
+            if (pipeline.scmRepo) {
+                sha = pipeline.scmRepo.name;
+            } else {
+                try {
+                    // User has good permissions, create an event
+                    sha = await scm.getCommitSha(scmConfig);
+                } catch (err) {
+                    if (err.statusCode) {
+                        throw boom.boomify(err, { statusCode: err.statusCode });
+                    }
                 }
             }
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -1033,6 +1033,19 @@ describe('event plugin test', () => {
                 delete testEvent.builds;
             });
         });
+
+        it('skips requests to GitHub if scmRepo is available', () => {
+            pipelineMock.scmRepo = { name: 'repository-name' };
+            eventConfig.sha = 'repository-name';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getCommitSha);
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
     });
 
     describe('PUT /events/{id}/stop', () => {


### PR DESCRIPTION
Related to #1

Skip redundant requests to GitHub if `scmRepo` is available.

* Modify `plugins/events/create.js` to check if `scmRepo` is available before making requests to GitHub.
* Retrieve the repository name from `pipelines.scmRepo` if available.
* Use the repository name from `pipelines.scmRepo` to avoid redundant requests to GitHub.
* Update the handler function to implement these changes.
* Add a test case in `test/plugins/events.test.js` to verify that requests to GitHub are skipped if `scmRepo` is available.
* Ensure the test case checks that the repository name is retrieved from `pipelines.scmRepo`.
* Verify that redundant requests to GitHub are not made during the build process.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eisenhowerj/screwdriver/issues/1?shareId=1f1e4c1d-6820-425e-90f4-9c0771543c0d).